### PR TITLE
Migrate to ganache

### DIFF
--- a/src/contracts/engine/Engine.ts
+++ b/src/contracts/engine/Engine.ts
@@ -2,9 +2,20 @@ import { EngineAbi } from '../../abis/Engine.abi';
 import { Contract } from '../../Contract';
 import { Address } from '../../Address';
 import { toBigNumber } from '../../utils/toBigNumber';
+import { Environment } from '../../Environment';
+import BigNumber from 'bignumber.js';
+
+export interface EngineDeployArguments {
+  delay: BigNumber;
+  registry: Address;
+}
 
 export class Engine extends Contract {
   public static readonly abi = EngineAbi;
+
+  public static deploy(environment: Environment, bytecode: string, from: Address, args: EngineDeployArguments) {
+    return super.createDeployment<Engine>(environment, bytecode, from, [args.delay.toString(), args.registry]);
+  }
 
   /**
    * Gets the amgu price.

--- a/src/contracts/fund/policies/AddressList.test.ts
+++ b/src/contracts/fund/policies/AddressList.test.ts
@@ -3,18 +3,15 @@ import { AddressList } from './AddressList';
 import { TestEnvironment, createTestEnvironment } from '../../../utils/tests/createTestEnvironment';
 import { AddressListBytecode } from '../../../abis/AddressList.bin';
 import { randomAddress } from '../../../utils/tests/randomAddress';
-import { Address } from '../../../Address';
 import { sameAddress } from '../../../utils/sameAddress';
 
 describe('AddressList', () => {
   let environment: TestEnvironment;
   let addressList: AddressList;
-  let addresses: Address[];
+  const addresses = R.range(0, 5).map(address => randomAddress());
 
   beforeAll(async () => {
     environment = await createTestEnvironment();
-
-    addresses = R.range(0, 5).map(address => randomAddress());
 
     const deploy = AddressList.deploy(environment, AddressListBytecode, environment.accounts[0], addresses);
     addressList = await deploy.send(await deploy.estimateGas());

--- a/src/contracts/fund/policies/AssetBlacklist.test.ts
+++ b/src/contracts/fund/policies/AssetBlacklist.test.ts
@@ -1,19 +1,16 @@
 import * as R from 'ramda';
 import { AssetBlacklist } from './AssetBlacklist';
 import { TestEnvironment, createTestEnvironment } from '../../../utils/tests/createTestEnvironment';
-import { Address } from '../../../Address';
 import { randomAddress } from '../../../utils/tests/randomAddress';
 import { AssetBlacklistBytecode } from '../../../abis/AssetBlacklist.bin';
 
 describe('AssetBlacklist', () => {
   let environment: TestEnvironment;
   let assetBlacklist: AssetBlacklist;
-  let addresses: Address[];
+  const addresses = R.range(0, 5).map(address => randomAddress());
 
   beforeAll(async () => {
     environment = await createTestEnvironment();
-
-    addresses = R.range(0, 5).map(address => randomAddress());
 
     const deploy = AssetBlacklist.deploy(environment, AssetBlacklistBytecode, environment.accounts[0], addresses);
     assetBlacklist = await deploy.send(await deploy.estimateGas());

--- a/src/contracts/fund/policies/AssetWhitelist.test.ts
+++ b/src/contracts/fund/policies/AssetWhitelist.test.ts
@@ -1,19 +1,16 @@
 import * as R from 'ramda';
 import { AssetWhitelist } from './AssetWhitelist';
 import { TestEnvironment, createTestEnvironment } from '../../../utils/tests/createTestEnvironment';
-import { Address } from '../../../Address';
 import { randomAddress } from '../../../utils/tests/randomAddress';
 import { AssetWhitelistBytecode } from '../../../abis/AssetWhitelist.bin';
 
 describe('AssetWhitelist', () => {
   let environment: TestEnvironment;
   let assetWhitelist: AssetWhitelist;
-  let addresses: Address[];
+  const addresses = R.range(0, 5).map(address => randomAddress());
 
   beforeAll(async () => {
     environment = await createTestEnvironment();
-
-    addresses = R.range(0, 5).map(address => randomAddress());
 
     const deploy = AssetWhitelist.deploy(environment, AssetWhitelistBytecode, environment.accounts[0], addresses);
     assetWhitelist = await deploy.send(await deploy.estimateGas());

--- a/src/contracts/fund/policies/AssetWhitelist.test.ts
+++ b/src/contracts/fund/policies/AssetWhitelist.test.ts
@@ -1,29 +1,27 @@
-import { Eth } from 'web3-eth';
-import { HttpProvider } from 'web3-providers';
-import { Environment } from '../../../Environment';
+import * as R from 'ramda';
 import { AssetWhitelist } from './AssetWhitelist';
+import { TestEnvironment, createTestEnvironment } from '../../../utils/tests/createTestEnvironment';
+import { Address } from '../../../Address';
+import { randomAddress } from '../../../utils/tests/randomAddress';
+import { AssetWhitelistBytecode } from '../../../abis/AssetWhitelist.bin';
 
 describe('AssetWhitelist', () => {
-  let environment: Environment;
+  let environment: TestEnvironment;
   let assetWhitelist: AssetWhitelist;
+  let addresses: Address[];
 
-  beforeAll(() => {
-    // TODO: This should be replaced with a local ganache test environment using proper test fixtures.
-    const client = new Eth(new HttpProvider('https://mainnet.melonport.com'));
-    environment = new Environment(client);
-    assetWhitelist = new AssetWhitelist(environment, '0x0a0ada038b2d4f29a9790a8c22903a1c654b9f8a');
+  beforeAll(async () => {
+    environment = await createTestEnvironment();
+
+    addresses = R.range(0, 5).map(address => randomAddress());
+
+    const deploy = AssetWhitelist.deploy(environment, AssetWhitelistBytecode, environment.accounts[0], addresses);
+    assetWhitelist = await deploy.send(await deploy.estimateGas());
   });
 
-  it('should return the index of an asset on the whitelist', async () => {
-    const result = await assetWhitelist.getAssetIndex('0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2');
-    expect(result).toBeGreaterThanOrEqual(0);
-  });
-
-  it('should return the members of the whitelist', async () => {
-    const result = await assetWhitelist.getMembers();
-    result.map(address => {
-      expect(address.startsWith('0x')).toBe(true);
-    });
+  it('should return the correct position', async () => {
+    const result = await assetWhitelist.getPosition();
+    expect(result).toBe(0);
   });
 
   it('should return the correct identifier', async () => {

--- a/src/contracts/fund/policies/AssetWhitelist.ts
+++ b/src/contracts/fund/policies/AssetWhitelist.ts
@@ -4,9 +4,14 @@ import { applyMixins } from '../../../utils/applyMixins';
 import { Policy } from './Policy';
 import { AddressList } from './AddressList';
 import { AssetWhitelistAbi } from '../../../abis/AssetWhitelist.abi';
+import { Environment } from '../../../Environment';
 
 export class AssetWhitelist extends Contract {
   public static readonly abi = AssetWhitelistAbi;
+
+  public static deploy(environment: Environment, bytecode: string, from: Address, members: Address[]) {
+    return super.createDeployment<AssetWhitelist>(environment, bytecode, from, [members]);
+  }
 
   /**
    * Gets the maximum number of positions.

--- a/src/contracts/fund/policies/MaxConcentration.test.ts
+++ b/src/contracts/fund/policies/MaxConcentration.test.ts
@@ -6,12 +6,10 @@ import BigNumber from 'bignumber.js';
 describe('MaxConcentration', () => {
   let environment: TestEnvironment;
   let maxConcentration: MaxConcentration;
-  let max: BigNumber;
+  const max = new BigNumber('100000000000000000');
 
   beforeAll(async () => {
     environment = await createTestEnvironment();
-
-    max = new BigNumber('100000000000000000');
 
     const deploy = MaxConcentration.deploy(environment, MaxConcentrationBytecode, environment.accounts[0], max);
     maxConcentration = await deploy.send(await deploy.estimateGas());

--- a/src/contracts/fund/policies/MaxConcentration.test.ts
+++ b/src/contracts/fund/policies/MaxConcentration.test.ts
@@ -1,22 +1,25 @@
-import { Eth } from 'web3-eth';
-import { HttpProvider } from 'web3-providers';
-import { Environment } from '../../../Environment';
 import { MaxConcentration } from './MaxConcentration';
+import { TestEnvironment, createTestEnvironment } from '../../../utils/tests/createTestEnvironment';
+import { MaxConcentrationBytecode } from '../../../abis/MaxConcentration.bin';
+import BigNumber from 'bignumber.js';
 
-describe('AddressList', () => {
-  let environment: Environment;
+describe('MaxConcentration', () => {
+  let environment: TestEnvironment;
   let maxConcentration: MaxConcentration;
+  let max: BigNumber;
 
-  beforeAll(() => {
-    // TODO: This should be replaced with a local ganache test environment using proper test fixtures.
-    const client = new Eth(new HttpProvider('https://mainnet.melonport.com'));
-    environment = new Environment(client);
-    maxConcentration = new MaxConcentration(environment, '0x042fcadfe10396ff5d11791357161af71ca51865');
+  beforeAll(async () => {
+    environment = await createTestEnvironment();
+
+    max = new BigNumber('100000000000000000');
+
+    const deploy = MaxConcentration.deploy(environment, MaxConcentrationBytecode, environment.accounts[0], max);
+    maxConcentration = await deploy.send(await deploy.estimateGas());
   });
 
   it('should return the price tolerance', async () => {
     const result = await maxConcentration.getMaxConcentration();
-    expect(result.isGreaterThanOrEqualTo(0)).toBe(true);
+    expect(result.isEqualTo(max)).toBe(true);
   });
 
   it('should return the correct identifier', async () => {

--- a/src/contracts/fund/policies/MaxConcentration.ts
+++ b/src/contracts/fund/policies/MaxConcentration.ts
@@ -3,9 +3,16 @@ import { MaxConcentrationAbi } from '../../../abis/MaxConcentration.abi';
 import { applyMixins } from '../../../utils/applyMixins';
 import { Policy } from './Policy';
 import { toBigNumber } from '../../../utils/toBigNumber';
+import { Environment } from '../../../Environment';
+import { Address } from '../../../Address';
+import BigNumber from 'bignumber.js';
 
 export class MaxConcentration extends Contract {
   public static readonly abi = MaxConcentrationAbi;
+
+  public static deploy(environment: Environment, bytecode: string, from: Address, maxConcentration: BigNumber) {
+    return super.createDeployment<MaxConcentration>(environment, bytecode, from, [maxConcentration.toString()]);
+  }
 
   /**
    * Gets the maximum concentration of an asset in the portfolio.

--- a/src/contracts/fund/policies/MaxPositions.test.ts
+++ b/src/contracts/fund/policies/MaxPositions.test.ts
@@ -1,22 +1,24 @@
-import { Eth } from 'web3-eth';
-import { HttpProvider } from 'web3-providers';
-import { Environment } from '../../../Environment';
 import { MaxPositions } from './MaxPositions';
+import { TestEnvironment, createTestEnvironment } from '../../../utils/tests/createTestEnvironment';
+import { MaxPositionsBytecode } from '../../../abis/MaxPositions.bin';
 
-describe('AddressList', () => {
-  let environment: Environment;
+describe('MaxPositions', () => {
+  let environment: TestEnvironment;
   let maxPositions: MaxPositions;
+  let max: number;
 
-  beforeAll(() => {
-    // TODO: This should be replaced with a local ganache test environment using proper test fixtures.
-    const client = new Eth(new HttpProvider('https://mainnet.melonport.com'));
-    environment = new Environment(client);
-    maxPositions = new MaxPositions(environment, '0x136f30369c6f387e537b0920ab616240662b9125');
+  beforeAll(async () => {
+    environment = await createTestEnvironment();
+
+    max = 10;
+
+    const deploy = MaxPositions.deploy(environment, MaxPositionsBytecode, environment.accounts[0], max);
+    maxPositions = await deploy.send(await deploy.estimateGas());
   });
 
-  it('should return the price tolerance', async () => {
+  it('should return the max number of positions', async () => {
     const result = await maxPositions.getMaxPositions();
-    expect(result.isGreaterThanOrEqualTo(0)).toBe(true);
+    expect(result).toEqual(max);
   });
 
   it('should return the correct identifier', async () => {

--- a/src/contracts/fund/policies/MaxPositions.test.ts
+++ b/src/contracts/fund/policies/MaxPositions.test.ts
@@ -5,12 +5,10 @@ import { MaxPositionsBytecode } from '../../../abis/MaxPositions.bin';
 describe('MaxPositions', () => {
   let environment: TestEnvironment;
   let maxPositions: MaxPositions;
-  let max: number;
+  const max = 10;
 
   beforeAll(async () => {
     environment = await createTestEnvironment();
-
-    max = 10;
 
     const deploy = MaxPositions.deploy(environment, MaxPositionsBytecode, environment.accounts[0], max);
     maxPositions = await deploy.send(await deploy.estimateGas());

--- a/src/contracts/fund/policies/MaxPositions.ts
+++ b/src/contracts/fund/policies/MaxPositions.ts
@@ -2,10 +2,16 @@ import { Contract } from '../../../Contract';
 import { MaxPositionsAbi } from '../../../abis/MaxPositions.abi';
 import { applyMixins } from '../../../utils/applyMixins';
 import { Policy } from './Policy';
-import { toBigNumber } from '../../../utils/toBigNumber';
+import { Environment } from '../../../Environment';
+import { Address } from '../../../Address';
+import { hexToNumber } from 'web3-utils';
 
 export class MaxPositions extends Contract {
   public static readonly abi = MaxPositionsAbi;
+
+  public static deploy(environment: Environment, bytecode: string, from: Address, maxPositions: number) {
+    return super.createDeployment<MaxPositions>(environment, bytecode, from, [maxPositions]);
+  }
 
   /**
    * Gets the maximum number of positions.
@@ -13,8 +19,8 @@ export class MaxPositions extends Contract {
    * @param block The block number to execute the call on.
    */
   public async getMaxPositions(block?: number) {
-    const result = await this.makeCall<string>('maxPositions', undefined, block);
-    return toBigNumber(result);
+    const result = await this.makeCall<number>('maxPositions', undefined, block);
+    return hexToNumber(result);
   }
 }
 

--- a/src/contracts/fund/policies/Policy.ts
+++ b/src/contracts/fund/policies/Policy.ts
@@ -15,7 +15,7 @@ export class Policy extends Contract {
   public static readonly abi = PolicyAbi;
 
   public static deploy(environment: Environment, bytecode: string, from: Address) {
-    return super.createDeployment<Policy>(environment, bytecode, from);
+    return super.createDeployment<Policy>(environment, bytecode, from, []);
   }
 
   /**

--- a/src/contracts/fund/policies/PriceTolerance.test.ts
+++ b/src/contracts/fund/policies/PriceTolerance.test.ts
@@ -6,12 +6,10 @@ import BigNumber from 'bignumber.js';
 describe('PriceTolerance', () => {
   let environment: TestEnvironment;
   let priceTolerance: PriceTolerance;
-  let tolerance: number;
+  const tolerance = 10;
 
   beforeAll(async () => {
     environment = await createTestEnvironment();
-
-    tolerance = 10;
 
     const deploy = PriceTolerance.deploy(environment, PriceToleranceBytecode, environment.accounts[0], tolerance);
     priceTolerance = await deploy.send(await deploy.estimateGas());

--- a/src/contracts/fund/policies/PriceTolerance.test.ts
+++ b/src/contracts/fund/policies/PriceTolerance.test.ts
@@ -1,21 +1,24 @@
-import { Eth } from 'web3-eth';
-import { HttpProvider } from 'web3-providers';
-import { Environment } from '../../../Environment';
 import { PriceTolerance } from './PriceTolerance';
+import { TestEnvironment, createTestEnvironment } from '../../../utils/tests/createTestEnvironment';
+import { PriceToleranceBytecode } from '../../../abis/PriceTolerance.bin';
+import BigNumber from 'bignumber.js';
 
-describe('AddressList', () => {
-  let environment: Environment;
+describe('PriceTolerance', () => {
+  let environment: TestEnvironment;
   let priceTolerance: PriceTolerance;
+  let tolerance: number;
 
-  beforeAll(() => {
-    // TODO: This should be replaced with a local ganache test environment using proper test fixtures.
-    const client = new Eth(new HttpProvider('https://mainnet.melonport.com'));
-    environment = new Environment(client);
-    priceTolerance = new PriceTolerance(environment, '0xde723fcc4a29400bae09ab341c914f4ba9b97e56');
+  beforeAll(async () => {
+    environment = await createTestEnvironment();
+
+    tolerance = 10;
+
+    const deploy = PriceTolerance.deploy(environment, PriceToleranceBytecode, environment.accounts[0], tolerance);
+    priceTolerance = await deploy.send(await deploy.estimateGas());
   });
 
   it('should return the price tolerance', async () => {
     const result = await priceTolerance.getPriceTolerance();
-    expect(result.isGreaterThanOrEqualTo(0)).toBe(true);
+    expect(result.isEqualTo(new BigNumber('1e16').multipliedBy(tolerance))).toBe(true);
   });
 });

--- a/src/contracts/fund/policies/PriceTolerance.ts
+++ b/src/contracts/fund/policies/PriceTolerance.ts
@@ -3,9 +3,15 @@ import { PriceToleranceAbi } from '../../../abis/PriceTolerance.abi';
 import { applyMixins } from '../../../utils/applyMixins';
 import { toBigNumber } from '../../../utils/toBigNumber';
 import { Policy } from './Policy';
+import { Environment } from '../../../Environment';
+import { Address } from '../../../Address';
 
 export class PriceTolerance extends Contract {
   public static readonly abi = PriceToleranceAbi;
+
+  public static deploy(environment: Environment, bytecode: string, from: Address, tolerance: number) {
+    return super.createDeployment<PriceTolerance>(environment, bytecode, from, [tolerance]);
+  }
 
   /**
    * Gets the price tolerance

--- a/src/contracts/fund/policies/UserWhitelist.test.ts
+++ b/src/contracts/fund/policies/UserWhitelist.test.ts
@@ -1,19 +1,16 @@
 import * as R from 'ramda';
 import { UserWhitelist } from './UserWhitelist';
 import { TestEnvironment, createTestEnvironment } from '../../../utils/tests/createTestEnvironment';
-import { Address } from '../../../Address';
 import { randomAddress } from '../../../utils/tests/randomAddress';
 import { UserWhitelistBytecode } from '../../../abis/UserWhitelist.bin';
 
 describe('UserWhitelist', () => {
   let environment: TestEnvironment;
   let userWhiteList: UserWhitelist;
-  let addresses: Address[];
+  const addresses = R.range(0, 5).map(() => randomAddress());
 
   beforeAll(async () => {
     environment = await createTestEnvironment();
-
-    addresses = R.range(0, 5).map(address => randomAddress());
 
     const deploy = UserWhitelist.deploy(environment, UserWhitelistBytecode, environment.accounts[0], addresses);
     userWhiteList = await deploy.send(await deploy.estimateGas());

--- a/src/contracts/fund/trading/Trading.test.ts
+++ b/src/contracts/fund/trading/Trading.test.ts
@@ -4,14 +4,13 @@ import { deployHub } from '../../../utils/tests/deployHub';
 import { deployTrading } from '../../../utils/tests/deployTrading';
 import { deployRegistry } from '../../../utils/tests/deployRegistry';
 import { randomAddress } from '../../../utils/tests/randomAddress';
-import { Address } from '../../../Address';
 import { Weth } from '../../dependencies/Weth';
 import { deployWeth } from '../../../utils/tests/deployWeth';
 
 describe('Trading', () => {
   let environment: TestEnvironment;
   let trading: Trading;
-  let exchangeAddress: Address;
+  let exchangeAddress = randomAddress();
   let weth: Weth;
 
   beforeAll(async () => {
@@ -24,7 +23,6 @@ describe('Trading', () => {
 
     weth = await deployWeth(environment, environment.accounts[0]);
 
-    exchangeAddress = randomAddress();
     const adapterAddress = randomAddress();
     const registry = await deployRegistry(environment, environment.accounts[0], environment.accounts[0]);
     const tx = registry.registerExchangeAdapter(environment.accounts[0], {

--- a/src/utils/tests/deployEngine.ts
+++ b/src/utils/tests/deployEngine.ts
@@ -1,0 +1,9 @@
+import { Address } from '../../Address';
+import { TestEnvironment } from './createTestEnvironment';
+import { EngineDeployArguments, Engine } from '../../contracts/engine/Engine';
+import { EngineBytecode } from '../../abis/Engine.bin';
+
+export async function deployEngine(environment: TestEnvironment, creator: Address, args: EngineDeployArguments) {
+  const deploy = Engine.deploy(environment, EngineBytecode, creator, args);
+  return await deploy.send(await deploy.estimateGas());
+}


### PR DESCRIPTION
Migrated all tests to ganache.

Except:
- `Policy.ts`: need to check with @travs why Policy.sol exports empty byte code
- `Accounting.ts` and `CanonicalPriceFeed.ts`: need to mock some tests (too complex to setup whole web of contracts needed for some calls)
