### PR TITLE
 Fix an incorrect typedef on a Spoke method

### DIFF
--- a/src/contracts/fund/hub/Spoke.ts
+++ b/src/contracts/fund/hub/Spoke.ts
@@ -69,6 +69,7 @@ export class Spoke extends Contract {
    * Checks if the contract is initialized.
    *
    * @param block The block number to execute the call on.
+   * @returns A boolean where True indicates the spoke has been initialized.
    */
   public isInitialized(block?: number) {
     return this.makeCall<boolean>('initialized', undefined, block);

--- a/src/contracts/fund/hub/Spoke.ts
+++ b/src/contracts/fund/hub/Spoke.ts
@@ -71,7 +71,7 @@ export class Spoke extends Contract {
    * @param block The block number to execute the call on.
    */
   public isInitialized(block?: number) {
-    return this.makeCall<string>('initialized', undefined, block);
+    return this.makeCall<boolean>('initialized', undefined, block);
   }
 
   /**


### PR DESCRIPTION
The public method `isInitialized()` on the Spoke class was typed to return a string. This PR updates it to return a boolean, where a True result indicates that the spoke has been initialized. 