### PR TITLE
Custom names and historic data for exchanges, policies and tokens

### DIFF
--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -38,7 +38,7 @@ export class DeployedEnvironment extends Environment {
   ) {
     super(eth, options);
 
-    this.policies = availablePolicies;
+    this.policies = availablePolicies();
     this.tokens = availableTokens(deployment);
     this.exchanges = availableExchanges(deployment);
   }

--- a/src/utils/availableExchanges.ts
+++ b/src/utils/availableExchanges.ts
@@ -1,4 +1,5 @@
 import { DeploymentOutput } from '../Deployment';
+import { toChecksumAddress } from 'web3-utils';
 
 export enum ExchangeIdentifier {
   'MelonEngine' = 'MelonEngine',
@@ -8,13 +9,14 @@ export enum ExchangeIdentifier {
 }
 
 export interface ExchangeDefinition {
-  id: ExchangeIdentifier;
+  id: ExchangeIdentifier | string;
   name: string;
   exchange: string;
   adapter: string;
+  historic?: boolean;
 }
 
-export function availableExchanges(deployment: DeploymentOutput): ExchangeDefinition[] {
+export function availableExchanges(deployment: DeploymentOutput, includeHistoric?: boolean): ExchangeDefinition[] {
   const exchanges = [
     deployment.melon && {
       name: 'MelonEngine',
@@ -42,5 +44,17 @@ export function availableExchanges(deployment: DeploymentOutput): ExchangeDefini
     },
   ];
 
-  return exchanges.filter(value => !!(value && value.exchange && value.adapter));
+  const historicExchanges = [
+    {
+      name: 'ZeroEx (v. 2.0)',
+      id: 'ZeroExV20',
+      adapter: toChecksumAddress('0x3ecfe6f8414ed517366a5e6f7f7fc74ef21caac9'),
+      exchange: toChecksumAddress('0x080bf510fcbf18b91105470639e9561022937712'),
+      historic: true,
+    },
+  ];
+
+  return [...exchanges, ...(includeHistoric && historicExchanges)].filter(
+    value => !!(value && value.exchange && value.adapter),
+  );
 }

--- a/src/utils/availableExchanges.ts
+++ b/src/utils/availableExchanges.ts
@@ -13,7 +13,7 @@ export interface ExchangeDefinition {
   name: string;
   exchange: string;
   adapter: string;
-  historic?: boolean;
+  historic: boolean;
 }
 
 export function availableExchanges(deployment: DeploymentOutput, includeHistoric?: boolean): ExchangeDefinition[] {
@@ -23,24 +23,28 @@ export function availableExchanges(deployment: DeploymentOutput, includeHistoric
       id: ExchangeIdentifier.MelonEngine,
       exchange: deployment.melon.addr.Engine,
       adapter: deployment.melon.addr.EngineAdapter,
+      historic: false,
     },
     deployment.kyber && {
       name: 'KyberNetwork',
       id: ExchangeIdentifier.KyberNetwork,
       adapter: deployment.melon.addr.KyberAdapter,
       exchange: deployment.kyber.addr.KyberNetworkProxy,
+      historic: false,
     },
     deployment.oasis && {
       name: 'OasisDex',
       id: ExchangeIdentifier.OasisDex,
       adapter: deployment.melon.addr.MatchingMarketAdapter,
       exchange: deployment.oasis.addr.OasisDexExchange,
+      historic: false,
     },
     deployment.zeroex && {
       name: 'ZeroEx',
       id: ExchangeIdentifier.ZeroEx,
       adapter: deployment.melon.addr.ZeroExV2Adapter,
       exchange: deployment.zeroex.addr.ZeroExV2Exchange,
+      historic: false,
     },
   ];
 

--- a/src/utils/availablePolicies.ts
+++ b/src/utils/availablePolicies.ts
@@ -6,7 +6,7 @@ export interface PolicyDefinition {
   id: string;
   name: string;
   signatures: string[];
-  historic?: boolean;
+  historic: boolean;
 }
 
 const historicPolicies = [] as PolicyDefinition[];
@@ -24,33 +24,39 @@ export function availablePolicies(includeHistoric?: boolean): PolicyDefinition[]
       id: 'priceTolerance',
       name: 'Price tolerance',
       signatures: [...tradingSignatures],
+      historic: false,
     },
 
     {
       id: 'maxPositions',
       name: 'Maximum number of positions',
       signatures: [...tradingSignatures, ...investmentSignatures],
+      historic: false,
     },
 
     {
       id: 'maxConcentration',
       name: 'Maximum concentration',
       signatures: [...tradingSignatures, ...investmentSignatures],
+      historic: false,
     },
     {
       id: 'userWhitelist',
       name: 'Investor whitelist',
       signatures: [...investmentSignatures],
+      historic: false,
     },
     {
       id: 'assetWhitelist',
       name: 'Asset whitelist',
       signatures: [...tradingSignatures, ...investmentSignatures],
+      historic: false,
     },
     {
       id: 'assetBlacklist',
       name: 'Asset blacklist',
       signatures: [...tradingSignatures, ...investmentSignatures],
+      historic: false,
     },
   ] as PolicyDefinition[];
 

--- a/src/utils/availablePolicies.ts
+++ b/src/utils/availablePolicies.ts
@@ -6,56 +6,53 @@ export interface PolicyDefinition {
   id: string;
   name: string;
   signatures: string[];
+  historic?: boolean;
 }
 
-const tradingSignatures = [
-  encodeFunctionSignature(ExchangeAdapterAbi, 'makeOrder'),
-  encodeFunctionSignature(ExchangeAdapterAbi, 'takeOrder'),
-];
+const historicPolicies = [] as PolicyDefinition[];
 
-const investmentSignatures = [encodeFunctionSignature(ParticipationAbi, 'requestInvestment')];
+export function availablePolicies(includeHistoric?: boolean): PolicyDefinition[] {
+  const tradingSignatures = [
+    encodeFunctionSignature(ExchangeAdapterAbi, 'makeOrder'),
+    encodeFunctionSignature(ExchangeAdapterAbi, 'takeOrder'),
+  ];
 
-const priceTolerance: PolicyDefinition = {
-  id: 'priceTolerance',
-  name: 'Price tolerance',
-  signatures: [...tradingSignatures],
-};
+  const investmentSignatures = [encodeFunctionSignature(ParticipationAbi, 'requestInvestment')];
 
-const maxPositions: PolicyDefinition = {
-  id: 'maxPositions',
-  name: 'Maximum number of positions',
-  signatures: [...tradingSignatures, ...investmentSignatures],
-};
+  const policies = [
+    {
+      id: 'priceTolerance',
+      name: 'Price tolerance',
+      signatures: [...tradingSignatures],
+    },
 
-const maxConcentration: PolicyDefinition = {
-  id: 'maxConcentration',
-  name: 'Maximum concentration',
-  signatures: [...tradingSignatures, ...investmentSignatures],
-};
+    {
+      id: 'maxPositions',
+      name: 'Maximum number of positions',
+      signatures: [...tradingSignatures, ...investmentSignatures],
+    },
 
-const userWhitelist: PolicyDefinition = {
-  id: 'userWhitelist',
-  name: 'User whitelist',
-  signatures: [...investmentSignatures],
-};
+    {
+      id: 'maxConcentration',
+      name: 'Maximum concentration',
+      signatures: [...tradingSignatures, ...investmentSignatures],
+    },
+    {
+      id: 'userWhitelist',
+      name: 'Investor whitelist',
+      signatures: [...investmentSignatures],
+    },
+    {
+      id: 'assetWhitelist',
+      name: 'Asset whitelist',
+      signatures: [...tradingSignatures, ...investmentSignatures],
+    },
+    {
+      id: 'assetBlacklist',
+      name: 'Asset blacklist',
+      signatures: [...tradingSignatures, ...investmentSignatures],
+    },
+  ] as PolicyDefinition[];
 
-const assetWhitelist: PolicyDefinition = {
-  id: 'assetWhitelist',
-  name: 'Asset whitelist',
-  signatures: [...tradingSignatures, ...investmentSignatures],
-};
-
-const assetBlacklist: PolicyDefinition = {
-  id: 'assetBlacklist',
-  name: 'Asset blacklist',
-  signatures: [...tradingSignatures, ...investmentSignatures],
-};
-
-export const availablePolicies = [
-  priceTolerance,
-  maxPositions,
-  maxConcentration,
-  userWhitelist,
-  assetWhitelist,
-  assetBlacklist,
-];
+  return [...policies, ...(includeHistoric && historicPolicies)];
+}

--- a/src/utils/availableTokens.ts
+++ b/src/utils/availableTokens.ts
@@ -5,7 +5,7 @@ export interface TokenDefinition {
   name: string;
   address: string;
   decimals: number;
-  historic?: boolean;
+  historic: boolean;
 }
 
 function replaceProperties(token: TokenDefinition): Partial<TokenDefinition> {
@@ -31,6 +31,7 @@ export function availableTokens(deployment: DeploymentOutput, includeHistoric?: 
       address: deployment.tokens.addr[symbol],
       decimals: deployment.tokens.conf[symbol].decimals,
       name: deployment.tokens.conf[symbol].name,
+      historic: false,
     }))
     .map(token => {
       return { ...token, ...replaceProperties(token) };

--- a/src/utils/availableTokens.ts
+++ b/src/utils/availableTokens.ts
@@ -5,16 +5,36 @@ export interface TokenDefinition {
   name: string;
   address: string;
   decimals: number;
+  historic?: boolean;
 }
 
-export function availableTokens(deployment: DeploymentOutput): TokenDefinition[] {
-  const symbols = Object.keys(deployment.tokens.addr);
-  const tokens = symbols.map(symbol => ({
-    symbol,
-    address: deployment.tokens.addr[symbol],
-    decimals: deployment.tokens.conf[symbol].decimals,
-    name: deployment.tokens.conf[symbol].name,
-  }));
+function replaceProperties(token: TokenDefinition): Partial<TokenDefinition> {
+  switch (token.symbol) {
+    case 'WETH':
+      return { name: 'Wrapped Ether' };
+    case 'ZRX':
+      return { name: '0x protocol token' };
+    case 'MKR':
+      return { name: 'Maker token' };
+    default:
+      return {};
+  }
+}
 
-  return tokens;
+const historicTokens = [] as TokenDefinition[];
+
+export function availableTokens(deployment: DeploymentOutput, includeHistoric?: boolean): TokenDefinition[] {
+  const symbols = Object.keys(deployment.tokens.addr);
+  const tokens = symbols
+    .map(symbol => ({
+      symbol,
+      address: deployment.tokens.addr[symbol],
+      decimals: deployment.tokens.conf[symbol].decimals,
+      name: deployment.tokens.conf[symbol].name,
+    }))
+    .map(token => {
+      return { ...token, ...replaceProperties(token) };
+    });
+
+  return [...tokens, ...(includeHistoric && historicTokens)];
 }


### PR DESCRIPTION
- Add the ability to overwrite properties for tokens (e.g. name)
- Add the ability to include historic records (e.g. exchanges that are no longer used but still need to be displayed properly)

This is the base for https://github.com/avantgardefinance/interface/issues/99